### PR TITLE
Add MMOItems type range filtering and fix jitpack Oraxen POM resolution

### DIFF
--- a/api/src/main/java/de/skyslycer/hmcwraps/serialization/wrap/range/RangeSettings.java
+++ b/api/src/main/java/de/skyslycer/hmcwraps/serialization/wrap/range/RangeSettings.java
@@ -14,10 +14,12 @@ public class RangeSettings {
     private ValueRangeSettings<String> executableItems;
     private ValueRangeSettings<String> craftEngine;
     private ValueRangeSettings<String> mmoItems;
+    private ValueRangeSettings<String> mmoItemsType;
 
     public RangeSettings(ValueRangeSettings<Integer> modelId, ValueRangeSettings<String> color, ValueRangeSettings<String> itemsAdder,
                          ValueRangeSettings<String> oraxen, ValueRangeSettings<String> mythic, ValueRangeSettings<String> nexo,
-                         ValueRangeSettings<String> executableItems, ValueRangeSettings<String> craftEngine, ValueRangeSettings<String> mmoItems) {
+                         ValueRangeSettings<String> executableItems, ValueRangeSettings<String> craftEngine, ValueRangeSettings<String> mmoItems,
+                         ValueRangeSettings<String> mmoItemsType) {
         this.modelId = modelId;
         this.color = color;
         this.itemsadder = itemsAdder;
@@ -27,6 +29,7 @@ public class RangeSettings {
         this.executableItems = executableItems;
         this.craftEngine = craftEngine;
         this.mmoItems = mmoItems;
+        this.mmoItemsType = mmoItemsType;
     }
 
     public RangeSettings() {}
@@ -67,10 +70,15 @@ public class RangeSettings {
         return mmoItems;
     }
 
+    public ValueRangeSettings<String> getMmoItemsType() {
+        return mmoItemsType;
+    }
+
     public static RangeSettings empty() {
         return new RangeSettings(new ValueRangeSettings<>(), new ValueRangeSettings<>(), new ValueRangeSettings<>(),
                 new ValueRangeSettings<>(), new ValueRangeSettings<>(), new ValueRangeSettings<>(),
-                new ValueRangeSettings<>(), new ValueRangeSettings<>(), new ValueRangeSettings<>());
+                new ValueRangeSettings<>(), new ValueRangeSettings<>(), new ValueRangeSettings<>(),
+                new ValueRangeSettings<>());
     }
 
 }

--- a/api/src/main/java/de/skyslycer/hmcwraps/wrap/modifiers/plugin/MMOItemsModifier.java
+++ b/api/src/main/java/de/skyslycer/hmcwraps/wrap/modifiers/plugin/MMOItemsModifier.java
@@ -17,19 +17,23 @@ public class MMOItemsModifier implements WrapModifier {
     private final HMCWraps plugin;
 
     private final NamespacedKey originalKey;
+    private final NamespacedKey originalTypeKey;
 
     public MMOItemsModifier(HMCWraps plugin) {
         this.plugin = plugin;
         this.originalKey = new NamespacedKey(plugin, "original-mmoitems-id");
+        this.originalTypeKey = new NamespacedKey(plugin, "original-mmoitems-type");
     }
 
     @Override
     public void wrap(@Nullable Wrap wrap, @Nullable Wrap currentWrap, ItemStack item, Player player) {
         if (wrap != null && currentWrap == null) {
             setOriginalId(item, getRealId(item));
+            setOriginalType(item, getRealType(item));
         }
         if (wrap == null) {
             setOriginalId(item, null);
+            setOriginalType(item, null);
         }
     }
 
@@ -72,6 +76,47 @@ public class MMOItemsModifier implements WrapModifier {
             }
         }
         return id;
+    }
+
+    /**
+     * Get the original MMOItems type (e.g. SWORD, AXE) of the item.
+     *
+     * @param item The item
+     * @return The original MMOItems type
+     */
+    public String getOriginalType(ItemStack item) {
+        PersistentDataContainer container = item.getItemMeta().getPersistentDataContainer();
+        return container.get(originalTypeKey, PersistentDataType.STRING);
+    }
+
+    private void setOriginalType(ItemStack item, String type) {
+        var meta = item.getItemMeta();
+        if (type != null) {
+            meta.getPersistentDataContainer().set(originalTypeKey, PersistentDataType.STRING, type);
+        } else {
+            meta.getPersistentDataContainer().remove(originalTypeKey);
+        }
+        item.setItemMeta(meta);
+    }
+
+    /**
+     * Get the real MMOItems type of the item. If the item is wrapped, the original type will be returned.
+     * If it isn't wrapped, the current type will be returned.
+     *
+     * @param item The item
+     * @return The real MMOItems type
+     */
+    public String getRealType(ItemStack item) {
+        String type = null;
+        if (plugin.getWrapper().getWrap(item) != null) {
+            type = getOriginalType(item);
+        } else if (Bukkit.getPluginManager().isPluginEnabled("MMOItems")) {
+            String itemType = NBT.get(item, nbt -> (String) nbt.getString("MMOITEMS_ITEM_TYPE"));
+            if (itemType != null) {
+                type = itemType;
+            }
+        }
+        return type;
     }
 
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ allprojects {
 
     repositories {
         mavenCentral()
+        maven("https://jitpack.io")
         maven("https://repo.skyslycer.de/jitpack")
         maven("https://repo.skyslycer.de/mirrors")
         maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")

--- a/core/src/main/java/de/skyslycer/hmcwraps/actions/register/DefaultActionRegister.java
+++ b/core/src/main/java/de/skyslycer/hmcwraps/actions/register/DefaultActionRegister.java
@@ -312,7 +312,7 @@ public class DefaultActionRegister {
                         || !isSameRange(range.getOraxen(), currentRange.getOraxen()) || !isSameRange(range.getItemsAdder(), currentRange.getItemsAdder())
                         || !isSameRange(range.getMythic(), currentRange.getMythic()) || isSameRange(range.getNexo(), currentRange.getNexo())
                         || !isSameRange(range.getExecutableItems(), currentRange.getExecutableItems()) || !isSameRange(range.getCraftEngine(), currentRange.getCraftEngine())
-                        || !isSameRange(range.getMmoItems(), currentRange.getMmoItems())) {
+                        || !isSameRange(range.getMmoItems(), currentRange.getMmoItems()) || !isSameRange(range.getMmoItemsType(), currentRange.getMmoItemsType())) {
                     return;
                 }
                 current.remove(currentWrap);

--- a/core/src/main/java/de/skyslycer/hmcwraps/wrap/WrapperImpl.java
+++ b/core/src/main/java/de/skyslycer/hmcwraps/wrap/WrapperImpl.java
@@ -222,7 +222,8 @@ public class WrapperImpl implements Wrapper {
                 && isValidType(wrap.getRange().getMythic(), getModifiers().mythic().getRealId(item))
                 && isValidType(wrap.getRange().getExecutableItems(), getModifiers().executableItems().getRealId(item))
                 && isValidType(wrap.getRange().getNexo(), getModifiers().nexo().getRealId(item))
-                && isValidType(wrap.getRange().getMmoItems(), getModifiers().mmoItems().getRealId(item)));
+                && isValidType(wrap.getRange().getMmoItems(), getModifiers().mmoItems().getRealId(item))
+                && isValidType(wrap.getRange().getMmoItemsType(), getModifiers().mmoItems().getRealType(item)));
     }
 
     private <T> boolean isValidType(ValueRangeSettings<T> settings, T value) {


### PR DESCRIPTION
- Add range.mmo-items-type (include/exclude) so a wrap can be restricted to specific MMOItems item types (e.g. WARRIOR_SWORD), not just individual item IDs. Mirrors the existing mmo-items id-based range.
- Add jitpack.io directly to the repository list; the skyslycer.de jitpack mirror was 404ing on the Oraxen -SNAPSHOT POM while serving the JAR, breaking the build.